### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For system-wide installation, you must have permissions and use with `sudo`.
 **REEFFIT** requires the following *Python* packages as dependencies, all of which can be installed through [`pip`](https://pip.pypa.io/).
 ```json
 cvxopt >= 1.1.6
-joblib >= 0.5.4
+0.11 >= joblib >= 0.5.4
 matplotlib >= 1.1.1
 numpy >= 1.6.1
 scipy >= 0.9.0
@@ -25,6 +25,8 @@ pymc >= 2.2
 
 rdatkit >= 1.0.4
 ```
+
+* To use the --njobs parameter currently, joblib package version needs to be 0.11 or less.
 
 * Note that you should have `RDATKit` installed and properly set up as well (see https://github.com/ribokit/RDATKit)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For system-wide installation, you must have permissions and use with `sudo`.
 
 **REEFFIT** requires the following *Python* packages as dependencies, all of which can be installed through [`pip`](https://pip.pypa.io/).
 ```json
-cvxopt >= 1.1.6
+cvxopt == 1.1.6
 0.11 >= joblib >= 0.5.4
 matplotlib >= 1.1.1
 numpy >= 1.6.1
@@ -26,7 +26,7 @@ pymc >= 2.2
 rdatkit >= 1.0.4
 ```
 
-* To use the --njobs parameter currently, joblib package version needs to be 0.11 or less.
+* To use the --njobs parameter currently, joblib package version needs to be 0.11 or less and cvxopt version needs to be 1.1.6
 
 * Note that you should have `RDATKit` installed and properly set up as well (see https://github.com/ribokit/RDATKit)
 


### PR DESCRIPTION
Changes to README to specify joblib version <=0.11. Compatibility issues due to changes in joblib >= 0.12, that now uses loky as the default backend. Specifying backend="multiprocessing" in joblib function Parallel() does not entirely resolve this issue and needs to be investigated further.